### PR TITLE
Add translatable string for the theme description field

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -6,6 +6,8 @@ There's a frood who really knows where his towel is
 
 - Fix issue preventing setting theme on virtual hosted sites and directories.
   [davidjb]
+- Add translatable string for theme field description.
+  [davidjb]
 
 
 1.0b2 (2013-08-15)

--- a/src/collective/behavior/localdiazo/behavior.py
+++ b/src/collective/behavior/localdiazo/behavior.py
@@ -29,7 +29,7 @@ class ILocalDiazo(ILocalRegistry):
     """
     theme = schema.Choice(
         title=_(u"Theme"),
-        description=_(u""),
+        description=_(u"Select a theme to enable a different look and feel."),
         vocabulary='collective.behavior.localdiazo.vocabularies.diazo_themes',
         required=True
     )

--- a/src/collective/behavior/localdiazo/locales/collective.behavior.localdiazo.pot
+++ b/src/collective/behavior/localdiazo/locales/collective.behavior.localdiazo.pot
@@ -1,7 +1,10 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 msgid ""
 msgstr ""
-"Project-Id-Version: collective.behavior.localdiazo\n"
-"POT-Creation-Date: 2013-08-14 19:57+0000\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2013-09-18 04:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,17 +15,17 @@ msgstr ""
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
+"Domain: collective.behavior.localdiazo\n"
 
-#: collective/behavior/localdiazo/behavior.py:31
-msgid ""
-msgstr ""
-
-#: collective/behavior/localdiazo/behavior.py:21
+#: collective/behavior/localdiazo/behavior.py:22
 msgid "No local theme"
 msgstr ""
 
-#: collective/behavior/localdiazo/behavior.py:30
+#: collective/behavior/localdiazo/behavior.py:32
+msgid "Select a theme to enable a different look and feel."
+msgstr ""
+
+#: collective/behavior/localdiazo/behavior.py:31
 msgid "Theme"
 msgstr ""
 

--- a/src/collective/behavior/localdiazo/locales/es/LC_MESSAGES/collective.behavior.localdiazo.po
+++ b/src/collective/behavior/localdiazo/locales/es/LC_MESSAGES/collective.behavior.localdiazo.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.behavior.localdiazo\n"
-"POT-Creation-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"POT-Creation-Date: 2013-09-18 04:38+0000\n"
 "PO-Revision-Date: 2013-08-14 16:57-0300\n"
 "Last-Translator: Héctor Velarde <hector.velarde@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,11 +15,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: collective/behavior/localdiazo/behavior.py:21
+#: collective/behavior/localdiazo/behavior.py:22
 msgid "No local theme"
 msgstr "Sin tema local"
 
-#: collective/behavior/localdiazo/behavior.py:30
+#: collective/behavior/localdiazo/behavior.py:32
+msgid "Select a theme to enable a different look and feel."
+msgstr ""
+
+#: collective/behavior/localdiazo/behavior.py:31
 msgid "Theme"
 msgstr "Tema"
 

--- a/src/collective/behavior/localdiazo/locales/pt_BR/LC_MESSAGES/collective.behavior.localdiazo.po
+++ b/src/collective/behavior/localdiazo/locales/pt_BR/LC_MESSAGES/collective.behavior.localdiazo.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.behavior.localdiazo\n"
-"POT-Creation-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"POT-Creation-Date: 2013-09-18 04:38+0000\n"
 "PO-Revision-Date: 2013-08-14 16:58-0300\n"
 "Last-Translator: Héctor Velarde <hector.velarde@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,11 +15,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: collective/behavior/localdiazo/behavior.py:21
+#: collective/behavior/localdiazo/behavior.py:22
 msgid "No local theme"
 msgstr "Sem tema local"
 
-#: collective/behavior/localdiazo/behavior.py:30
+#: collective/behavior/localdiazo/behavior.py:32
+msgid "Select a theme to enable a different look and feel."
+msgstr ""
+
+#: collective/behavior/localdiazo/behavior.py:31
 msgid "Theme"
 msgstr "Tema"
 


### PR DESCRIPTION
Previously, this was not translatable because it was an empty string.  This changes the default behaviour of the field (eg it now has a description), but it does mean that it can be translated (or in my case overridden on a specific site).
